### PR TITLE
[TSK-19] 얼굴 : Live2D 아바타의 눈 깜빡임 캡쳐

### DIFF
--- a/Assets/FaceTracking.cs
+++ b/Assets/FaceTracking.cs
@@ -21,8 +21,8 @@ public class FaceTracking : MonoBehaviour
     private CubismParameter _faceAngleZ;
     private CubismParameter _bodyAngleX;
     private CubismParameter _bodyAngleY;
-    private CubismParameter _leftEye;
-    private CubismParameter _rightEye;
+    private CubismParameter _leftEyeBlink;
+    private CubismParameter _rightEyeBlink;
     private CubismParameter _mouthForm;
     private CubismParameter _mouthOpen;
 
@@ -61,8 +61,8 @@ public class FaceTracking : MonoBehaviour
     private void LateUpdate()
     {
         // 표정 : 눈
-        _leftEye.Value = _updateLeftEye;
-        _rightEye.Value = _updateRightEye;
+        _leftEyeBlink.Value = _updateLeftEye;
+        _rightEyeBlink.Value = _updateRightEye;
 
         // 표정 : 입
         _mouthForm.Value = _updateMouthForm;
@@ -89,8 +89,6 @@ public class FaceTracking : MonoBehaviour
                 UpdateFaceTransform( arFace );
                 UpdateBlendShape( arFace );
 
-                _log.text = arFace.transform.position.ToString();
-
                 // TODO 삭제 대상 @Choi 25.01.05
                 Debug.Log( arFace.transform.position );
             }
@@ -110,8 +108,8 @@ public class FaceTracking : MonoBehaviour
         _bodyAngleX = model.Parameters[22];
         _bodyAngleY = model.Parameters[23];
 
-        _leftEye = model.Parameters[3];
-        _rightEye = model.Parameters[5];
+        _leftEyeBlink = model.Parameters[4];
+        _rightEyeBlink = model.Parameters[6];
 
         _mouthForm = model.Parameters[17];
         _mouthOpen = model.Parameters[18];
@@ -126,9 +124,9 @@ public class FaceTracking : MonoBehaviour
         // 얼굴의 위치 정보 취득
         var faceRotation = arFace.transform.rotation;
 
-        var x = NormalizeAngle( faceRotation.eulerAngles.x )* 2f;
+        var x = NormalizeAngle( faceRotation.eulerAngles.x ) * 2f * -1f;
         var y = NormalizeAngle( faceRotation.eulerAngles.y );
-        var z = NormalizeAngle( faceRotation.eulerAngles.z )* 2f;
+        var z = NormalizeAngle( faceRotation.eulerAngles.z ) * 2f;
 
         // 새로운 얼굴 회전값을 변수에 대입
         _updateFaceAngleX = y;
@@ -150,9 +148,11 @@ public class FaceTracking : MonoBehaviour
             {
                 case ARKitBlendShapeLocation.EyeBlinkLeft:
                     _updateLeftEye = 1 - blendShapesARKit[i].coefficient;
+                    _log.text = $"L_Eye : {_updateLeftEye}";
                     continue;
                 case ARKitBlendShapeLocation.EyeBlinkRight:
                     _updateRightEye = 1 - blendShapesARKit[i].coefficient;
+                    _log.text = $"R_Eye : {_updateRightEye}";
                     continue;
                 case ARKitBlendShapeLocation.MouthFunnel:
                     _updateMouthForm = 1 - blendShapesARKit[i].coefficient * 2;


### PR DESCRIPTION
# 개요
[TSK-19] 얼굴 : Live2D 아바타의 눈 깜빡임 캡쳐

# 관련 URL
https://www.notion.so/Live2D-174e0fd63d3580ef903bde28a8b1738b?pvs=4

# 작업 내용
- ARKit에서 눈 깜빡임 이벤트를 감지하여 Live2D 아바타와 연동

# 셀프 동작 확인, 또는 체크한 항목
- [x] iPhone에서 빌드 및 실행하여 좌, 우 눈을 각각 깜빡였을 때 Live2D  캐릭터와 연동이 됨.
- [x] iPhone에서 빌드 및 실행하여 좌, 우 눈을 동시에 깜빡였을 때 Live2D  캐릭터와 연동이 됨.

## 동작 확인 자료
없음

# 기타 기재사항
없음